### PR TITLE
Fix client.py

### DIFF
--- a/beam_mysql/connector/client.py
+++ b/beam_mysql/connector/client.py
@@ -120,7 +120,7 @@ class MySQLClient:
                     # Query of the argument should be "DERIVED" because it is sub query of explain select.
                     # Count query should be "PRIMARY" or "SIMPLE" because it is not sub query.
                     if record["select_type"] in ("PRIMARY", "SIMPLE"):
-                        total_number = record["rows"]
+                        total_number = int(record["rows"])
             except MySQLConnectorError as e:
                 raise MySQLClientError(f"Failed to execute query: {count_query}, Raise exception: {e}")
 


### PR DESCRIPTION
Hello, I have the next error: 
**Error: '<=' not supported between instances of 'str' and 'int' [while running 'LeerData/Read/SDFBoundedSourceReader/ParDo(SDFBoundedSourceDoFn)/SplitAndSizeRestriction']**

 when I connected to a database with the next characteristics: 

Col name | Data Type | Not null | Auto-increment | key | Extra
-- | -- | -- | -- | -- | --
col1 | Int(11) unsigned | TRUE | TRUE | PRI | auto increment
col2 | Int(11) unsigned | TRUE | FALSE |   |  
col3 | longtext | TRUE | FALSE |   |  
col4 | Int(11) unsigned | TRUE | FALSE |   |  
col5 | longtext | TRUE | FALSE |   |  
col6 | datetime/* mar | TRUE | FALSE |   |  

I try with another db with similiar schema and the problem didn't appear, the unique difference is the Data type in col6:
Col name | Data Type | Not null | Auto-increment | key | Extra
-- | -- | -- | -- | -- | --
col1 | Int(11) unsigned | TRUE | TRUE | PRI | auto increment
col2 | Int(11) unsigned | TRUE | FALSE |   |  
col3 | longtext | TRUE | FALSE |   |  
col4 | Int(11) unsigned | TRUE | FALSE |   |  
col5 | longtext | TRUE | FALSE |   |  
col6 | datetime | TRUE | FALSE |   |  

I just transformed the record["rows"] to an int and the error disappeared.
I hope, this can help. Thank you.