### PR TITLE
fixed the version specification formats

### DIFF
--- a/beam_mysql/__init__.py
+++ b/beam_mysql/__init__.py
@@ -1,3 +1,3 @@
 """Beam - MySQL Connector information and utilities."""
 
-__version__ = "1.8.5"
+__version__ = "1.8.6"

--- a/beam_mysql/connector/client.py
+++ b/beam_mysql/connector/client.py
@@ -23,7 +23,9 @@ class MySQLClient:
         self._config = config
         self._validate_config(self._config)
 
-    def record_generator(self, query: str, dictionary=True) -> Generator[Dict, None, None]:
+    def record_generator(
+        self, query: str, dictionary=True
+    ) -> Generator[Dict, None, None]:
         """
         Generate dict record from raw data on mysql.
 
@@ -50,7 +52,9 @@ class MySQLClient:
                 for record in cur:
                     yield record
             except MySQLConnectorError as e:
-                raise MySQLClientError(f"Failed to execute query: {query}, Raise exception: {e}")
+                raise MySQLClientError(
+                    f"Failed to execute query: {query}, Raise exception: {e}"
+                )
 
             cur.close()
 
@@ -80,7 +84,9 @@ class MySQLClient:
 
                 record = cur.fetchone()
             except MySQLConnectorError as e:
-                raise MySQLClientError(f"Failed to execute query: {count_query}, Raise exception: {e}")
+                raise MySQLClientError(
+                    f"Failed to execute query: {count_query}, Raise exception: {e}"
+                )
 
             cur.close()
 
@@ -121,12 +127,16 @@ class MySQLClient:
                     if record["select_type"] in ("PRIMARY", "SIMPLE"):
                         total_number = record["rows"]
             except MySQLConnectorError as e:
-                raise MySQLClientError(f"Failed to execute query: {count_query}, Raise exception: {e}")
+                raise MySQLClientError(
+                    f"Failed to execute query: {count_query}, Raise exception: {e}"
+                )
 
             cur.close()
 
             if total_number <= 0:
-                raise mysql.connector.errors.Error(f"Failed to estimate total number of records. Query: {count_query}")
+                raise mysql.connector.errors.Error(
+                    f"Failed to estimate total number of records. Query: {count_query}"
+                )
             else:
                 return total_number
 
@@ -151,7 +161,9 @@ class MySQLClient:
                 logger.info(f"Successfully execute query: {query}")
             except MySQLConnectorError as e:
                 conn.rollback()
-                raise MySQLClientError(f"Failed to execute query: {query}, Raise exception: {e}")
+                raise MySQLClientError(
+                    f"Failed to execute query: {query}, Raise exception: {e}"
+                )
 
             cur.close()
 
@@ -159,7 +171,9 @@ class MySQLClient:
     def _validate_config(config: Dict):
         required_keys = {"host", "port", "database", "user", "password"}
         if not config.keys() == required_keys:
-            raise MySQLClientError(f"Config is not satisfied. required: {required_keys}, actual: {config.keys()}")
+            raise MySQLClientError(
+                f"Config is not satisfied. required: {required_keys}, actual: {config.keys()}"
+            )
 
     @staticmethod
     def _validate_query(query: str, statement: str) -> None:
@@ -181,7 +195,9 @@ class MySQLClient:
         cleansed_query = _remove_comments_and_cte(query)
 
         if statement and not cleansed_query.lower().startswith(statement.lower()):
-            raise MySQLClientError(f"Query expected to start with {statement} statement. Query: {query}")
+            raise MySQLClientError(
+                f"Query expected to start with {statement} statement. Query: {query}"
+            )
 
 
 class _MySQLConnection:

--- a/beam_mysql/connector/client.py
+++ b/beam_mysql/connector/client.py
@@ -1,9 +1,8 @@
 """A client of mysql."""
 
+import re
 from logging import INFO, getLogger
-from typing import Dict
-from typing import Generator
-from typing import List
+from typing import Dict, Generator
 
 import mysql.connector
 from mysql.connector.errors import Error as MySQLConnectorError
@@ -38,7 +37,7 @@ class MySQLClient:
         Raises:
             ~beam_mysql.connector.errors.MySQLClientError
         """
-        self._validate_query(query, [_SELECT_STATEMENT])
+        self._validate_query(query, _SELECT_STATEMENT)
 
         with _MySQLConnection(self._config) as conn:
             # buffered is false because it can be assumed that the data size is too large
@@ -68,7 +67,7 @@ class MySQLClient:
         Raises:
             ~beam_mysql.connector.errors.MySQLClientError
         """
-        self._validate_query(query, [_SELECT_STATEMENT])
+        self._validate_query(query, _SELECT_STATEMENT)
         count_query = f"SELECT COUNT(*) AS count FROM ({query}) as subq"
 
         with _MySQLConnection(self._config) as conn:
@@ -101,7 +100,7 @@ class MySQLClient:
         Raises:
             ~beam_mysql.connector.errors.MySQLClientError
         """
-        self._validate_query(query, [_SELECT_STATEMENT])
+        self._validate_query(query, _SELECT_STATEMENT)
         count_query = f"EXPLAIN SELECT * FROM ({query}) as subq"
 
         with _MySQLConnection(self._config) as conn:
@@ -141,7 +140,7 @@ class MySQLClient:
         Raises:
             ~beam_mysql.connector.errors.MySQLClientError
         """
-        self._validate_query(query, [_INSERT_STATEMENT])
+        self._validate_query(query, _INSERT_STATEMENT)
 
         with _MySQLConnection(self._config) as conn:
             cur = conn.cursor()
@@ -163,12 +162,26 @@ class MySQLClient:
             raise MySQLClientError(f"Config is not satisfied. required: {required_keys}, actual: {config.keys()}")
 
     @staticmethod
-    def _validate_query(query: str, statements: List[str]):
-        query = query.lstrip()
+    def _validate_query(query: str, statement: str) -> None:
+        def _remove_comments_and_cte(query):
+            # delete comments
+            query = re.sub(r"--.*\n", " ", query)
+            query = re.sub(r"/\*[.\s].*\*/", " ", query, flags=re.DOTALL)
+            # delete new line
+            query = query.replace("\n", " ")
+            # delete cte clause
+            query = re.sub(
+                r"WITH\s+(?:\w+\s+AS\s+\(.+?\)\s*,?\s*)+",
+                "",
+                query,
+                flags=re.IGNORECASE,
+            )
+            return query.strip()
 
-        for statement in statements:
-            if statement and not query.lower().startswith(statement.lower()):
-                raise MySQLClientError(f"Query expected to start with {statement} statement. Query: {query}")
+        cleansed_query = _remove_comments_and_cte(query)
+
+        if statement and not cleansed_query.lower().startswith(statement.lower()):
+            raise MySQLClientError(f"Query expected to start with {statement} statement. Query: {query}")
 
 
 class _MySQLConnection:

--- a/beam_mysql/connector/io.py
+++ b/beam_mysql/connector/io.py
@@ -38,7 +38,15 @@ class ReadFromMySQL(PTransform):
 
     def expand(self, pcoll: PCollection) -> PCollection:
         return pcoll | iobase.Read(
-            MySQLSource(self._query, self._host, self._database, self._user, self._password, self._port, self._splitter)
+            MySQLSource(
+                self._query,
+                self._host,
+                self._database,
+                self._user,
+                self._password,
+                self._port,
+                self._splitter,
+            )
         )
 
 
@@ -67,7 +75,13 @@ class WriteToMySQL(PTransform):
     def expand(self, pcoll: PCollection) -> PCollection:
         return pcoll | beam.ParDo(
             _WriteToMySQLFn(
-                self._host, self._database, self._table, self._user, self._password, self._port, self._batch_size
+                self._host,
+                self._database,
+                self._table,
+                self._user,
+                self._password,
+                self._port,
+                self._batch_size,
             )
         )
 
@@ -116,7 +130,9 @@ class _WriteToMySQLFn(beam.DoFn):
         column_str = ", ".join(columns)
         value_str = ", ".join(
             [
-                f"{'NULL' if value is None else value}" if isinstance(value, (type(None), int, float)) else f"'{value}'"
+                f"{'NULL' if value is None else value}"
+                if isinstance(value, (type(None), int, float))
+                else f"'{value}'"
                 for value in values
             ]
         )

--- a/beam_mysql/connector/io.py
+++ b/beam_mysql/connector/io.py
@@ -1,7 +1,6 @@
 """I/O connectors of mysql."""
 
-from typing import Dict
-from typing import Union
+from typing import Dict, Union
 
 import apache_beam as beam
 from apache_beam.io import iobase

--- a/beam_mysql/connector/source.py
+++ b/beam_mysql/connector/source.py
@@ -67,7 +67,9 @@ class MySQLSource(iobase.BoundedSource):
         if not self._is_builded:
             self._build_value()
 
-        for split in self._splitter.split(desired_bundle_size, start_position, stop_position):
+        for split in self._splitter.split(
+            desired_bundle_size, start_position, stop_position
+        ):
             yield split
 
     def _build_value(self):

--- a/beam_mysql/connector/source.py
+++ b/beam_mysql/connector/source.py
@@ -7,8 +7,7 @@ from apache_beam.options.value_provider import ValueProvider
 
 from beam_mysql.connector import splitters
 from beam_mysql.connector.client import MySQLClient
-from beam_mysql.connector.utils import cleanse_query
-from beam_mysql.connector.utils import get_runtime_value
+from beam_mysql.connector.utils import cleanse_query, get_runtime_value
 
 
 class MySQLSource(iobase.BoundedSource):

--- a/beam_mysql/connector/splitters.py
+++ b/beam_mysql/connector/splitters.py
@@ -1,16 +1,14 @@
 """A wrapper class of `~apache_beam.io.iobase.BoundedSource` functions."""
 
 import re
-from abc import ABCMeta
-from abc import abstractmethod
+from abc import ABCMeta, abstractmethod
 from datetime import datetime
-from typing import Callable
-from typing import Iterator
+from typing import Callable, Iterator
 
 from apache_beam.io import iobase
-from apache_beam.io.range_trackers import LexicographicKeyRangeTracker
-from apache_beam.io.range_trackers import OffsetRangeTracker
-from apache_beam.io.range_trackers import UnsplittableRangeTracker
+from apache_beam.io.range_trackers import (LexicographicKeyRangeTracker,
+                                           OffsetRangeTracker,
+                                           UnsplittableRangeTracker)
 from dateutil.relativedelta import relativedelta
 
 

--- a/examples/read_records_pipeline.py
+++ b/examples/read_records_pipeline.py
@@ -12,11 +12,19 @@ class ReadRecordsOptions(PipelineOptions):
     def _add_argparse_args(cls, parser):
         parser.add_value_provider_argument("--host", dest="host", default="localhost")
         parser.add_value_provider_argument("--port", dest="port", default=3307)
-        parser.add_value_provider_argument("--database", dest="database", default="test_db")
-        parser.add_value_provider_argument("--query", dest="query", default="SELECT * FROM test_db.tests;")
+        parser.add_value_provider_argument(
+            "--database", dest="database", default="test_db"
+        )
+        parser.add_value_provider_argument(
+            "--query", dest="query", default="SELECT * FROM test_db.tests;"
+        )
         parser.add_value_provider_argument("--user", dest="user", default="root")
-        parser.add_value_provider_argument("--password", dest="password", default="root")
-        parser.add_value_provider_argument("--output", dest="output", default="output/read-records-result")
+        parser.add_value_provider_argument(
+            "--password", dest="password", default="root"
+        )
+        parser.add_value_provider_argument(
+            "--output", dest="output", default="output/read-records-result"
+        )
 
 
 def run():
@@ -38,7 +46,10 @@ def run():
         p
         | "ReadFromMySQL" >> read_from_mysql
         | "NoTransform" >> beam.Map(lambda e: e)
-        | "WriteToText" >> beam.io.WriteToText(options.output, file_name_suffix=".txt", shard_name_template="")
+        | "WriteToText"
+        >> beam.io.WriteToText(
+            options.output, file_name_suffix=".txt", shard_name_template=""
+        )
     )
 
     p.run().wait_until_finish()

--- a/examples/write_records_pipeline.py
+++ b/examples/write_records_pipeline.py
@@ -11,10 +11,14 @@ class WriteRecordsOptions(PipelineOptions):
     def _add_argparse_args(cls, parser):
         parser.add_value_provider_argument("--host", dest="host", default="0.0.0.0")
         parser.add_value_provider_argument("--port", dest="port", default=3307)
-        parser.add_value_provider_argument("--database", dest="database", default="test_db")
+        parser.add_value_provider_argument(
+            "--database", dest="database", default="test_db"
+        )
         parser.add_value_provider_argument("--table", dest="table", default="tests")
         parser.add_value_provider_argument("--user", dest="user", default="root")
-        parser.add_value_provider_argument("--password", dest="password", default="root")
+        parser.add_value_provider_argument(
+            "--password", dest="password", default="root"
+        )
         parser.add_value_provider_argument("--batch_size", dest="batch_size", default=0)
 
 
@@ -35,7 +39,8 @@ def run():
 
     (
         p
-        | "ReadFromInMemory" >> beam.Create([{"name": "test data3"}, {"name": "test data4"}])
+        | "ReadFromInMemory"
+        >> beam.Create([{"name": "test data3"}, {"name": "test data4"}])
         | "NoTransform" >> beam.Map(lambda e: e)
         | "WriteToMySQL" >> write_to_mysql
     )

--- a/setup.py
+++ b/setup.py
@@ -22,18 +22,38 @@ class SimpleCommand(Command):
 
 class LintCommand(SimpleCommand):
     def run(self):
-        subprocess.run(["black", SRC_DIR_NAME, EXAMPLES_DIR_NAME, TESTS_DIR_NAME, "-l", "120", "--check", "--diff"])
+        subprocess.run(
+            [
+                "black",
+                SRC_DIR_NAME,
+                EXAMPLES_DIR_NAME,
+                TESTS_DIR_NAME,
+                "-l",
+                "120",
+                "--check",
+                "--diff",
+            ]
+        )
         subprocess.run(["mypy", SRC_DIR_NAME, EXAMPLES_DIR_NAME, TESTS_DIR_NAME])
 
 
 class FormatCommand(SimpleCommand):
     def run(self):
-        subprocess.run(["black", SRC_DIR_NAME, EXAMPLES_DIR_NAME, TESTS_DIR_NAME, "-l", "120"])
+        subprocess.run(
+            ["black", SRC_DIR_NAME, EXAMPLES_DIR_NAME, TESTS_DIR_NAME, "-l", "120"]
+        )
 
 
 def get_version():
     global_names = {}
-    exec(open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "beam_mysql/__init__.py")).read(), global_names)
+    exec(
+        open(
+            os.path.join(
+                os.path.dirname(os.path.abspath(__file__)), "beam_mysql/__init__.py"
+            )
+        ).read(),
+        global_names,
+    )
     return global_names["__version__"]
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,7 @@
 import os
 import subprocess
 
-from setuptools import Command
-from setuptools import find_packages
-from setuptools import setup
+from setuptools import Command, find_packages, setup
 
 SRC_DIR_NAME = "beam_mysql"
 EXAMPLES_DIR_NAME = "examples"

--- a/setup.py
+++ b/setup.py
@@ -54,8 +54,8 @@ PACKAGE_KEYWORDS = "apache beam mysql connector"
 PACKAGE_LONG_DESCRIPTION = README
 
 REQUIRED_PACKAGES = [
-    "apache-beam>=2.15.*",
-    "mysql-connector-python>=8.0.*",
+    "apache-beam>=2.15",
+    "mysql-connector-python>=8.0",
 ]
 
 setup(

--- a/tests/test_read_records_pipeline.py
+++ b/tests/test_read_records_pipeline.py
@@ -1,9 +1,9 @@
 """A test of read records pipeline."""
 
-from apache_beam.testing.test_pipeline import TestPipeline
-from apache_beam.testing.util import assert_that
-from apache_beam.testing.util import equal_to
 from datetime import date
+
+from apache_beam.testing.test_pipeline import TestPipeline
+from apache_beam.testing.util import assert_that, equal_to
 
 from beam_mysql.connector import splitters
 from beam_mysql.connector.io import ReadFromMySQL

--- a/tests/test_write_records_pipeline.py
+++ b/tests/test_write_records_pipeline.py
@@ -1,7 +1,8 @@
 """A test of write records pipeline."""
 
-import apache_beam as beam
 import datetime
+
+import apache_beam as beam
 from apache_beam.testing.test_pipeline import TestPipeline
 
 from beam_mysql.connector.io import WriteToMySQL

--- a/tests/test_write_records_pipeline.py
+++ b/tests/test_write_records_pipeline.py
@@ -38,12 +38,42 @@ class TestWriteRecordsPipeline(TestBase):
 
     def test_pipeline(self):
         expected = [
-            {"id": 1, "name": "test data1", "date": datetime.date(2020, 1, 1), "memo": "memo1"},
-            {"id": 2, "name": "test data2", "date": datetime.date(2020, 2, 2), "memo": None},
-            {"id": 3, "name": "test data3", "date": datetime.date(2020, 3, 3), "memo": "memo3"},
-            {"id": 4, "name": "test data4", "date": datetime.date(2020, 4, 4), "memo": None},
-            {"id": 5, "name": "test data5", "date": datetime.date(2020, 5, 5), "memo": None},
-            {"id": 6, "name": "test data6", "date": datetime.date(2020, 6, 6), "memo": None},
+            {
+                "id": 1,
+                "name": "test data1",
+                "date": datetime.date(2020, 1, 1),
+                "memo": "memo1",
+            },
+            {
+                "id": 2,
+                "name": "test data2",
+                "date": datetime.date(2020, 2, 2),
+                "memo": None,
+            },
+            {
+                "id": 3,
+                "name": "test data3",
+                "date": datetime.date(2020, 3, 3),
+                "memo": "memo3",
+            },
+            {
+                "id": 4,
+                "name": "test data4",
+                "date": datetime.date(2020, 4, 4),
+                "memo": None,
+            },
+            {
+                "id": 5,
+                "name": "test data5",
+                "date": datetime.date(2020, 5, 5),
+                "memo": None,
+            },
+            {
+                "id": 6,
+                "name": "test data6",
+                "date": datetime.date(2020, 6, 6),
+                "memo": None,
+            },
         ]
 
         with TestPipeline() as p:
@@ -58,7 +88,20 @@ class TestWriteRecordsPipeline(TestBase):
                 batch_size=BATCH_SIZE,
             )
 
-            (p | beam.Create([{"id": 6, "name": "test data6", "date": "2020-06-06", "memo": None}]) | write_to_mysql)
+            (
+                p
+                | beam.Create(
+                    [
+                        {
+                            "id": 6,
+                            "name": "test data6",
+                            "date": "2020-06-06",
+                            "memo": None,
+                        }
+                    ]
+                )
+                | write_to_mysql
+            )
 
         cur = self.conn.cursor(dictionary=True)
         cur.execute(f"SELECT * FROM {DATABASE}.{TABLE}")


### PR DESCRIPTION
## Pull Request Summary

This Pull Request modifies the versions in the `install_requires` section of the `setup.py` file. Please review the changes and consider merging.

## Changes Made

setup.py

- Before modification:

```python:setup.py
REQUIRED_PACKAGES = [
    "apache-beam>=2.15.*",
    "mysql-connector-python>=8.0.*",
]
```

- After modification:

```python:setup.py
REQUIRED_PACKAGES = [
    "apache-beam>=2.15",
    "mysql-connector-python>=8.0",
]
```

## Background of the Changes

I made these modifications to the version specifications because executing `poetry add beam-mysql-connector` resulted in a package build error. The error was as follows:

```bash
`'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Expected end or semicolon (after version specifier)`.
```

By removing the wildcard (`*`) , I resolved the issue.

## Test Results

After these changes, `poetry add beam-mysql-connector` builds and installs successfully.
